### PR TITLE
Upgrading aiohttp from 3.6.2 -> 3.7.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ cryptography==2.8
 pycryptodome==3.9.1
 urllib3==1.25.7
 python-status==1.0.1
-aiohttp==3.6.2
+aiohttp==3.7.3
 prometheus_client==0.7.1
 pycond==20201010
 blxr-rlp==0.6.0


### PR DESCRIPTION
No big feature changes from 3.6.2 -> 3.7.3.
Some python packages use version 3.7.3 since it's the latest, and bxcommon is incompatible with those.

Source for changes between versions:
https://github.com/aio-libs/aiohttp/releases