### PR TITLE
Add max size on ws provider

### DIFF
--- a/src/bxcommon/rpc/provider/ws_provider.py
+++ b/src/bxcommon/rpc/provider/ws_provider.py
@@ -62,7 +62,8 @@ class WsProvider(AbstractWsProvider):
         retry_connection: bool = False,
         queue_limit: int = constants.WS_PROVIDER_MAX_QUEUE_SIZE,
         headers: Optional[Dict] = None,
-        skip_ssl_cert_verify: bool = False
+        skip_ssl_cert_verify: bool = False,
+        max_message_size: Optional[int] = 2 ** 20,
     ):
         super(WsProvider, self).__init__(uri, retry_connection, queue_limit, headers)
         if uri.startswith("wss"):
@@ -71,11 +72,12 @@ class WsProvider(AbstractWsProvider):
             if skip_ssl_cert_verify:
                 ssl_context.check_hostname = False
             self.ssl_context = ssl_context
+            self.max_message_size = max_message_size
         else:
             self.ssl_context = None
 
     async def connect_websocket(self) -> websockets.WebSocketClientProtocol:
-        return await websockets.connect(self.uri, extra_headers=self.headers, ssl=self.ssl_context)
+        return await websockets.connect(self.uri, extra_headers=self.headers, ssl=self.ssl_context, max_size=self.max_message_size)
 
     async def call_bx(
         self,

--- a/src/bxcommon/rpc/provider/ws_provider.py
+++ b/src/bxcommon/rpc/provider/ws_provider.py
@@ -63,7 +63,7 @@ class WsProvider(AbstractWsProvider):
         queue_limit: int = constants.WS_PROVIDER_MAX_QUEUE_SIZE,
         headers: Optional[Dict] = None,
         skip_ssl_cert_verify: bool = False,
-        max_message_size: Optional[int] = 2 ** 20,
+        max_message_size: Optional[int] = 2 * 2 ** 20,  # 2MB
     ):
         super(WsProvider, self).__init__(uri, retry_connection, queue_limit, headers)
         if uri.startswith("wss"):
@@ -77,7 +77,12 @@ class WsProvider(AbstractWsProvider):
             self.ssl_context = None
 
     async def connect_websocket(self) -> websockets.WebSocketClientProtocol:
-        return await websockets.connect(self.uri, extra_headers=self.headers, ssl=self.ssl_context, max_size=self.max_message_size)
+        return await websockets.connect(
+            self.uri,
+            extra_headers=self.headers,
+            ssl=self.ssl_context,
+            max_size=self.max_message_size
+        )
 
     async def call_bx(
         self,


### PR DESCRIPTION
## Problem
I got this error when receiving messages:
```
Websocket disconnected due to transport layer exception: payload length exceeds size limit (1726310 > 1048576 bytes)
```

## Why
Some transactions has more than 1MB bytes


## Solution
The default max message size is 2**20, so I put a new parameter to set it.
